### PR TITLE
Chore: Confirm render

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ TODO:
 [x] If the user signs in and has saved comps, load the first one in their list.
 [x] Create an emergency shutoff if the app exceeds a certain cost threshold
 [x] Add a confirmation step to render action in VideoGen
+[x] Fix issue with video preview not opening on render success
 [ ] Tickmarks display in the app, but do not persist in the rendered video.
     Make sure tickmarks get rendered in the shapes in the video.
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ TODO:
     current composition re-renders. Try to prevent the re-render.
 [x] If the user signs in and has saved comps, load the first one in their list.
 [x] Create an emergency shutoff if the app exceeds a certain cost threshold
+[x] Add a confirmation step to render action in VideoGen
 [ ] Tickmarks display in the app, but do not persist in the rendered video.
     Make sure tickmarks get rendered in the shapes in the video.
 ```

--- a/src/components/Composition.tsx
+++ b/src/components/Composition.tsx
@@ -222,6 +222,12 @@ const Composition = ({
         const userDocRef = doc(firestore, 'users', authUser.uid);
         await updateDoc(userDocRef, { isRendering: true });
       } catch (err) {
+        if (err instanceof Error) {
+          loggy.error(
+            'Failed to update rendering status in database:',
+            err.message,
+          );
+        }
         loggy.error('Failed to update rendering status in database.');
       }
     }
@@ -266,8 +272,9 @@ const Composition = ({
       if (videoUrl) {
         setPreviewVideoUrl(videoUrl);
       }
-    } catch (pipelineErr) {
-      loggy.error('Render pipeline encountered an error.');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : '';
+      loggy.error('Render pipeline encountered an error.', msg);
       if (authUser?.uid) {
         const userDocRef = doc(firestore, 'users', authUser.uid);
         await updateDoc(userDocRef, { isRendering: false }).catch(() => {});

--- a/src/components/Composition.tsx
+++ b/src/components/Composition.tsx
@@ -206,7 +206,6 @@ const Composition = ({
     processVideo,
     isRendering: isRenderingLocalState,
     videoCreateError,
-    videoUrl,
   } = useProcessVideo();
 
   const exportToVideo = async () => {
@@ -265,12 +264,12 @@ const Composition = ({
 
       // 3. Wait for backend to generate the video
       loggy.info('Frames uploaded. Begin rendering video…');
-      await processVideo(newJobId);
+      const downloadUrl = await processVideo(newJobId);
 
       // 4. Display the newly generated video
       loggy.info('Video rendered. Showing preview…');
-      if (videoUrl) {
-        setPreviewVideoUrl(videoUrl);
+      if (downloadUrl) {
+        setPreviewVideoUrl(downloadUrl);
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : '';
@@ -404,16 +403,16 @@ const Composition = ({
           <Dialog.Positioner>
             <Dialog.Content>
               <Dialog.Header>
-                <Dialog.Title>Oof!</Dialog.Title>
+                <Dialog.Title>You're at your limit!</Dialog.Title>
               </Dialog.Header>
               <Dialog.Body pb={6}>
                 <Text fontSize='sm'>
-                  Your account is limited to {MAX_VIDEOS} videos. To render a
-                  new animation, you'll need to delete one of your existing
-                  videos from the controls panel.{' '}
-                  <Text as='span' color='#6a00ffff'>
-                    Before deleting, you can save the file to your device by
-                    clicking the video's download button.
+                  For now, accounts are limited to {MAX_VIDEOS} videos. To
+                  render a new animation, you'll need to delete one of your
+                  existing videos from the controls panel.{' '}
+                  <Text as='span' color='#6a00ff'>
+                    You can save the file to your device first, by clicking the
+                    video's download button.
                   </Text>
                 </Text>
               </Dialog.Body>

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -246,7 +246,7 @@ const ControlPanel = ({
 
                   <VStack w='full' gap={2} align='flex-start'>
                     <Flex w='full' h={8} align='center' justify='space-between'>
-                      <Text textStyle='sm'>Guide Paths</Text>
+                      <Text textStyle='sm' fontWeight='medium'>Guide Paths</Text>
                       <IconButton
                         size='xs'
                         aria-label='hide or show path'

--- a/src/components/ManageComps.tsx
+++ b/src/components/ManageComps.tsx
@@ -88,20 +88,20 @@ const ManageComps = ({
                                 Delete?
                               </Text>
                               <IconButton
-                                aria-label='Confirm'
-                                rounded='full'
-                                size='xs'
-                                onClick={deleteQueuedComp}
-                              >
-                                <FaCheck />
-                              </IconButton>
-                              <IconButton
                                 aria-label='Cancel'
                                 rounded='full'
                                 size='xs'
                                 onClick={() => setIdToDelete(null)}
                               >
                                 <FaXmark />
+                              </IconButton>
+                              <IconButton
+                                aria-label='Confirm'
+                                rounded='full'
+                                size='xs'
+                                onClick={deleteQueuedComp}
+                              >
+                                <FaCheck />
                               </IconButton>
                             </HStack>
                           ) : (

--- a/src/components/UserInfo.tsx
+++ b/src/components/UserInfo.tsx
@@ -10,6 +10,7 @@ const onErrorCallback = (errMsg: string) => {
   toaster.create({
     description: errMsg,
     type: 'error',
+    duration: 5000,
   });
 };
 

--- a/src/components/VideoGen.tsx
+++ b/src/components/VideoGen.tsx
@@ -1,26 +1,85 @@
-import { FaClapperboard } from 'react-icons/fa6';
-import { Flex, IconButton } from '@chakra-ui/react';
-import { MAGENTA } from '../constants';
+import { FaCheck, FaClapperboard, FaXmark } from 'react-icons/fa6';
+
+import {
+  Flex,
+  HStack,
+  IconButton,
+  Popover,
+  Portal,
+  Text,
+} from '@chakra-ui/react';
+
+import { GO_GREEN, MAGENTA, STOP_RED } from '../constants';
+import { useRef } from 'react';
 
 interface VideoGenProps {
   exportToVideo: () => Promise<void>;
   isUploadingOrRendering: boolean;
 }
 
-const VideoGen = ({ exportToVideo, isUploadingOrRendering }: VideoGenProps) => (
-  <Flex h={10} w={10} outline='1px solid #404040' p={1} borderRadius='sm'>
-    <IconButton
-      aria-label='Render video'
-      color='#4a4a4a'
-      _hover={{ color: MAGENTA, transition: 'color .3s ease' }}
-      disabled={isUploadingOrRendering}
-      onClick={exportToVideo}
-      size='xs'
-      variant='outline'
-    >
-      <FaClapperboard />
-    </IconButton>
-  </Flex>
-);
+const VideoGen = ({ exportToVideo, isUploadingOrRendering }: VideoGenProps) => {
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  return (
+    <Flex h={10} w={10} outline='1px solid #404040' p={1} borderRadius='sm'>
+      <Popover.Root
+        size='xs'
+        positioning={{ placement: 'top-end' }}
+        initialFocusEl={() => confirmButtonRef.current}
+      >
+        <Popover.Trigger asChild>
+          <IconButton
+            aria-label='Render video'
+            color='#4a4a4a'
+            _hover={{ color: MAGENTA, transition: 'color .3s ease' }}
+            disabled={isUploadingOrRendering}
+            size='xs'
+            variant='outline'
+          >
+            <FaClapperboard />
+          </IconButton>
+        </Popover.Trigger>
+        <Portal>
+          <Popover.Positioner>
+            <Popover.Content width='unset'>
+              <Popover.Arrow />
+              <Popover.Body>
+                <HStack justify='space-between'>
+                  <Text>Export as a video?</Text>
+                  <Flex gap={2}>
+                    <Popover.CloseTrigger asChild>
+                      <IconButton
+                        aria-label='Cancel'
+                        bg='#e8e8e8'
+                        color={STOP_RED}
+                        rounded='full'
+                        size='xs'
+                      >
+                        <FaXmark />
+                      </IconButton>
+                    </Popover.CloseTrigger>
+                    <Popover.CloseTrigger asChild>
+                      <IconButton
+                        aria-label='Confirm'
+                        bg='#e8e8e8'
+                        color={GO_GREEN}
+                        onClick={exportToVideo}
+                        ref={confirmButtonRef}
+                        rounded='full'
+                        size='xs'
+                      >
+                        <FaCheck />
+                      </IconButton>
+                    </Popover.CloseTrigger>
+                  </Flex>
+                </HStack>
+              </Popover.Body>
+            </Popover.Content>
+          </Popover.Positioner>
+        </Portal>
+      </Popover.Root>
+    </Flex>
+  );
+};
 
 export default VideoGen;

--- a/src/components/VideoList/VideoListItem.tsx
+++ b/src/components/VideoList/VideoListItem.tsx
@@ -100,7 +100,8 @@ const VideoListItem = ({
             setPreviewVideoUrl(videoUrl);
           } else {
             toaster.create({
-              description: 'This video is still generating! Check back in a few seconds.',
+              description:
+                'This video is still generating! Check back in a few seconds.',
               type: 'info',
             });
           }
@@ -150,16 +151,6 @@ const VideoListItem = ({
               Delete?
             </Text>
             <IconButton
-              aria-label='Confirm'
-              bg='#222'
-              color='#eee'
-              onClick={() => deleteQueuedVideo(videoId)}
-              rounded='full'
-              size='xs'
-            >
-              <FaCheck />
-            </IconButton>
-            <IconButton
               aria-label='Cancel'
               bg='#222'
               color='#eee'
@@ -168,6 +159,16 @@ const VideoListItem = ({
               size='xs'
             >
               <FaXmark />
+            </IconButton>
+            <IconButton
+              aria-label='Confirm'
+              bg='#222'
+              color='#eee'
+              onClick={() => deleteQueuedVideo(videoId)}
+              rounded='full'
+              size='xs'
+            >
+              <FaCheck />
             </IconButton>
           </HStack>
         ) : (

--- a/src/components/VideoList/VideoListItem.tsx
+++ b/src/components/VideoList/VideoListItem.tsx
@@ -103,6 +103,7 @@ const VideoListItem = ({
               description:
                 'This video is still generating! Check back in a few seconds.',
               type: 'info',
+              duration: 5000,
             });
           }
         }}

--- a/src/components/VideoList/index.tsx
+++ b/src/components/VideoList/index.tsx
@@ -47,7 +47,9 @@ const VideoList = () => {
 
   return (
     <VStack width='full' align='flex-start' gap={2} mt={4}>
-      <Text textStyle='sm'>My Videos</Text>
+      <Text textStyle='sm' fontWeight='medium'>
+        My Videos
+      </Text>
       <Box w='full' maxH='13.5rem' overflowY='auto'>
         {content}
       </Box>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,10 +15,14 @@ export const DURATION_FRAMES = 384;
 export const MINTY = '#a2ffec';
 
 export const PREVIEW_VIDEO_DIMS = {
-  WD: 848,// 624, // 848,
-  HT: 477,// 351, // 477,
+  WD: 848,
+  HT: 477,
 };
 
 export const MAGENTA = '#ff008c';
 
 export const MAX_VIDEOS = 5;
+
+export const STOP_RED = '#ff2f00';
+
+export const GO_GREEN = '#00a078';

--- a/src/hooks/useProcessVideo.ts
+++ b/src/hooks/useProcessVideo.ts
@@ -7,7 +7,6 @@ import { loggy } from '../utils/helpers';
 const cloudFunctionUrl = import.meta.env.VITE_PUBLIC_CLOUD_FUNCTION_URL;
 
 export const useProcessVideo = () => {
-  const [videoUrl, setVideoUrl] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -19,7 +18,6 @@ export const useProcessVideo = () => {
     
     setLoading(true);
     setError('');
-    setVideoUrl('');
 
     // Check if user is loaded and authenticated
     if (authLoading) {
@@ -77,7 +75,7 @@ export const useProcessVideo = () => {
 
       const data = await response.json();
       if (data.downloadUrl) {
-        setVideoUrl(data.downloadUrl);
+        return data.downloadUrl;
       }
       if (data.message) {
         loggy.info(data.message);
@@ -98,6 +96,5 @@ export const useProcessVideo = () => {
     processVideo,
     isRendering: loading,
     videoCreateError: error,
-    videoUrl,
   };
 };


### PR DESCRIPTION
* To prevent accidental requests to render the video (which could result in wasted Firebase usage costs), require the user to confirm they want to render their current animation
* Fix react state / async issue that causes video preview modal to not open when the render completes